### PR TITLE
fix(a32nx): update for GSX config

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/GSX.cfg
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/GSX.cfg
@@ -2,40 +2,45 @@
 icaotype = A20N
 parkingbrakestest = (L:A32NX_PARK_BRAKE_LEVER_POS,number) (L:A32NX_GND_EQP_IS_VISIBLE, number) ||
 nosegear = 8.26
+ceiling = 2.00
 refueling = 0
 battery = 1
 pushbackraise = 1
 pushbackdummyevent = 0
 pushbackcheckengines = 0
+ignoreicing = 0
 iscargo = 0
 trafficcones = 0
 preferredexit =  0
 wingrootpos = 2.36 -1.89 0.85
 wingtippos = 15.70 -7.41 1.84
 fuelpos = 9.63 -3.39 0.88
-waterpos = 1.28 -18.07 0.52
-lavatorypos = 0.59 -18.07 0.12
+waterpos = 0.55 -15.43 0.07
+lavatorypos = -0.73 -15.47 0.12
 gpupos = 3.29 11.06 -1.56
 bypasspinpos = 0.08 8.45 -1.42
 engine1pos = -5.67 0.50 -0.81
 engine2pos = 5.67 0.50 -0.80
 engine3pos = 0.00 0.00 0.00
 engine4pos = 0.00 0.00 0.00
+engine5pos = 0.00 0.00 0.00
+engine6pos = 0.00 0.00 0.00
+paxseatspos =  []
+crewseatspos =  []
+corridorsoffset =  []
 
 [exit1]
 pos = -1.88 8.51 0.86 4.00
 code = 1
 name = Passenger Door
+ceiling = 1.85
 embeddedStair = 0
 
 [exit2]
 remove = 1
 
 [exit3]
-pos = -1.60 -16.15 0.97 -12.00
-code = 3
-name = Passenger Aft Door
-embeddedStair = 0
+remove = 1
 
 [exit4]
 remove = 1
@@ -47,14 +52,16 @@ remove = 1
 pos = 1.80 -16.15 1.03 12.00
 code = 4
 name = Service Door AFT
+ceiling = 1.85
 embeddedStair = 0
 
 [cargo1]
 pos = 0.85 5.50 -0.40 -0.39
 code = 6
 name = Cargo Door
+ceiling = 1.8
 embeddedStair = 0
-uldcode = BELT
+uldcode = AKH
 
 [cargo2]
 remove = 1


### PR DESCRIPTION
## Summary of Changes

These are some fixes and additions for the GSX config file for the A32NX.

1. added contact points for the water and lavatory hose (water and lavatory trucks added with GSX version 3.1.5)
2. removed emergency exit (falsly assigned as a passenger door in the last update, 1 year ago). Until we have more animated doors, still only 1L (pax) and 4R (catering) is accessible.
3. changed baggage loader to container loader - with the correct container type for the A320 (AKH)
4. added ceiling definitions (mandatory since some updates ago)

## Screenshots (if necessary)
no

## References
no

## Additional context
no

Discord username (if different from GitHub): RogePete

## Testing instructions
For GSX users only:

- Check if the water and lavatory hose are connecting at the aircraft (and not in the air). 
- Check if (correct) containers are used for cargo loading
- Check if everything else works like before

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
